### PR TITLE
Add bruto column on payments table

### DIFF
--- a/pages/pagamentos.js
+++ b/pages/pagamentos.js
@@ -206,6 +206,7 @@ export default function PagamentosPage() {
                                         <th className="p-2">Empresa</th>
                                         <th className="p-2">Tipo</th>
                                         <th className="p-2">Parcela</th>
+                                        <th className="p-2">Valor Bruto</th>
                                         <th className="p-2">Valor Comissão</th>
                                         <th className="p-2">Data Recebida</th>
                                         <th className="p-2">Status</th>
@@ -219,6 +220,7 @@ export default function PagamentosPage() {
                                             <td className="p-2">{p.empresa}</td>
                                             <td className="p-2">{p.tipo}</td>
                                             <td className="p-2">{p.num_parcela}</td>
+                                            <td className="p-2">{p.valor_bruto}</td>
                                             <td className="p-2">{p.valor_liquido_comissao}</td>
                                             <td className="p-2">{p.data_recebida}</td>
                                             <td className="p-2">{p.status}</td>


### PR DESCRIPTION
## Summary
- show Valor Bruto before Valor Comissão on the Pagamentos page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688285e3ce4c832c80287b25015a0053