### PR TITLE
fix: ensure session context in client components

### DIFF
--- a/CODex_SessionContext_Fix_Report.md
+++ b/CODex_SessionContext_Fix_Report.md
@@ -1,0 +1,40 @@
+# Session Context Fix Report
+
+## Arquivos alterados
+- `pages/oportunidades.js`
+- `pages/pagamentos.js`
+- `components/Sidebar.js`
+- `components/Providers.tsx`
+- `pages/_app.js`
+
+## Justificativas
+- **pages/oportunidades.js**: marcado como Client Component para permitir o uso de `useSession` no ambiente cliente.
+- **pages/pagamentos.js**: adicionado `"use client"` para evitar uso de `useSession` em Server Components.
+- **components/Sidebar.js**: convertido em Client Component devido ao uso de `useSession`, `signIn` e `signOut`.
+- **components/Providers.tsx**: novo componente client que encapsula `SessionProvider`, isolando o contexto de sessão.
+- **pages/_app.js**: atualizado para usar o novo `Providers` mantendo o layout raiz como Server Component.
+
+## Resultado do `npm run build`
+Build executado com sucesso. Saída relevante:
+```
+├ ○ /configuracoes                         1.97 kB        94.7 kB
+├ ○ /gerenciar-usuarios                    1.93 kB        94.6 kB
+├ ○ /metas                                 2.45 kB        95.1 kB
+├ ○ /oportunidades                         4.38 kB         105 kB
+├ ○ /pagamentos                            2.39 kB        95.1 kB
+├ ○ /relatorios                            1.26 kB        93.9 kB
+├ ○ /relatorios/detalhamento-oportunidade  2.38 kB        95.1 kB
+├ ○ /relatorios/dsr                        3.36 kB          96 kB
+├ ○ /relatorios/extrato-mensal             2.35 kB          95 kB
+├ ○ /relatorios/metas-vs-realizado         1.74 kB        94.4 kB
+└ ○ /relatorios/pagamentos-em-atraso       2.06 kB        94.7 kB
++ First Load JS shared by all              97.5 kB
+  ├ chunks/framework-49c6cecf1f6d5795.js   44.9 kB
+  ├ chunks/main-b72093f7aa2e45f9.js        34 kB
+  ├ chunks/pages/_app-b0e311c1e5d39c0f.js  13 kB
+  └ other shared chunks (total)            5.65 kB
+
+○  (Static)   prerendered as static content
+ƒ  (Dynamic)  server-rendered on demand
+
+```

--- a/CODex_SessionContext_Fix_Report.md
+++ b/CODex_SessionContext_Fix_Report.md
@@ -3,38 +3,41 @@
 ## Arquivos alterados
 - `pages/oportunidades.js`
 - `pages/pagamentos.js`
+- `pages/index.js`
+- `pages/gerenciar-usuarios.js`
+- `pages/calcular-dsr.js`
+- `pages/configuracoes.js`
+- `pages/metas.js`
+- `pages/relatorios/dsr.js`
+- `pages/relatorios/pagamentos-em-atraso.js`
+- `pages/relatorios/extrato-mensal.js`
+- `pages/relatorios/detalhamento-oportunidade.js`
 - `components/Sidebar.js`
 - `components/Providers.tsx`
+- `components/GlobalImportProvider.tsx`
+- `components/ImportModal.tsx`
 - `pages/_app.js`
 
 ## Justificativas
-- **pages/oportunidades.js**: marcado como Client Component para permitir o uso de `useSession` no ambiente cliente.
-- **pages/pagamentos.js**: adicionado `"use client"` para evitar uso de `useSession` em Server Components.
-- **components/Sidebar.js**: convertido em Client Component devido ao uso de `useSession`, `signIn` e `signOut`.
-- **components/Providers.tsx**: novo componente client que encapsula `SessionProvider`, isolando o contexto de sessão.
-- **pages/_app.js**: atualizado para usar o novo `Providers` mantendo o layout raiz como Server Component.
+- **pages/*.js**: adicionada a diretiva `"use client"` para garantir que `useSession` seja executado somente no cliente.
+- **components/Sidebar.js**: marcado como Client Component devido ao uso de `useSession`, `signIn` e `signOut`.
+- **components/Providers.tsx**: ajustado para envolver a aplicação com `SessionProvider` e `GlobalImportProvider`.
+- **components/GlobalImportProvider.tsx** e **components/ImportModal.tsx**: novos componentes client para disponibilizar o modal de importação globalmente.
+- **pages/_app.js**: atualizado para usar `<Providers>` mantendo o layout raiz como Server Component.
 
 ## Resultado do `npm run build`
 Build executado com sucesso. Saída relevante:
 ```
-├ ○ /configuracoes                         1.97 kB        94.7 kB
-├ ○ /gerenciar-usuarios                    1.93 kB        94.6 kB
-├ ○ /metas                                 2.45 kB        95.1 kB
+├ ○ /configuracoes                         1.97 kB        94.9 kB
+├ ○ /gerenciar-usuarios                    1.93 kB        94.9 kB
+├ ○ /metas                                 2.45 kB        95.4 kB
 ├ ○ /oportunidades                         4.38 kB         105 kB
-├ ○ /pagamentos                            2.39 kB        95.1 kB
-├ ○ /relatorios                            1.26 kB        93.9 kB
-├ ○ /relatorios/detalhamento-oportunidade  2.38 kB        95.1 kB
-├ ○ /relatorios/dsr                        3.36 kB          96 kB
-├ ○ /relatorios/extrato-mensal             2.35 kB          95 kB
-├ ○ /relatorios/metas-vs-realizado         1.74 kB        94.4 kB
-└ ○ /relatorios/pagamentos-em-atraso       2.06 kB        94.7 kB
-+ First Load JS shared by all              97.5 kB
-  ├ chunks/framework-49c6cecf1f6d5795.js   44.9 kB
-  ├ chunks/main-b72093f7aa2e45f9.js        34 kB
-  ├ chunks/pages/_app-b0e311c1e5d39c0f.js  13 kB
-  └ other shared chunks (total)            5.65 kB
-
-○  (Static)   prerendered as static content
-ƒ  (Dynamic)  server-rendered on demand
-
+├ ○ /pagamentos                            2.39 kB        95.3 kB
+├ ○ /relatorios                            1.26 kB        94.2 kB
+├ ○ /relatorios/detalhamento-oportunidade  2.38 kB        95.3 kB
+├ ○ /relatorios/dsr                        3.36 kB        96.3 kB
+├ ○ /relatorios/extrato-mensal             2.35 kB        95.3 kB
+├ ○ /relatorios/metas-vs-realizado         1.74 kB        94.7 kB
+└ ○ /relatorios/pagamentos-em-atraso       2.06 kB          95 kB
++ First Load JS shared by all              97.9 kB
 ```

--- a/components/GlobalImportProvider.tsx
+++ b/components/GlobalImportProvider.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+import ImportModal from "./ImportModal";
+
+interface GlobalImportContextValue {
+  open: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+const GlobalImportContext = createContext<GlobalImportContextValue | undefined>(undefined);
+
+export function GlobalImportProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  const openModal = () => setOpen(true);
+  const closeModal = () => setOpen(false);
+
+  return (
+    <GlobalImportContext.Provider value={{ open, openModal, closeModal }}>
+      {children}
+      <ImportModal />
+    </GlobalImportContext.Provider>
+  );
+}
+
+export function useGlobalImport() {
+  const ctx = useContext(GlobalImportContext);
+  if (!ctx) throw new Error("useGlobalImport must be used within GlobalImportProvider");
+  return ctx;
+}

--- a/components/ImportModal.tsx
+++ b/components/ImportModal.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useGlobalImport } from "./GlobalImportProvider";
+
+export default function ImportModal() {
+  const { open, closeModal } = useGlobalImport();
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white p-4 rounded shadow">
+        <p>Importar dados</p>
+        <button onClick={closeModal} className="mt-2 px-3 py-1 bg-gray-200 rounded">Fechar</button>
+      </div>
+    </div>
+  );
+}

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default function Providers({ children, session }) {
+  return <SessionProvider session={session}>{children}</SessionProvider>;
+}

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import { GlobalImportProvider } from "./GlobalImportProvider";
 
 export default function Providers({ children, session }) {
-  return <SessionProvider session={session}>{children}</SessionProvider>;
+  return (
+    <SessionProvider session={session}>
+      <GlobalImportProvider>{children}</GlobalImportProvider>
+    </SessionProvider>
+  );
 }

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useSession, signIn, signOut } from "next-auth/react";

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,16 +1,15 @@
 // /pages/_app.js (Versão Atualizada)
 
-import { SessionProvider } from "next-auth/react";
 import '../styles/globals.css';
 import Layout from '@/components/Layout';
+import Providers from '@/components/Providers';
 
 export default function App({ Component, pageProps: { session, ...pageProps } }) {
-  // Envolve o Layout com o SessionProvider
   return (
-    <SessionProvider session={session}>
+    <Providers session={session}>
       <Layout>
         <Component {...pageProps} />
       </Layout>
-    </SessionProvider>
+    </Providers>
   );
 }

--- a/pages/calcular-dsr.js
+++ b/pages/calcular-dsr.js
@@ -1,3 +1,4 @@
+"use client";
 import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useSession } from 'next-auth/react';

--- a/pages/configuracoes.js
+++ b/pages/configuracoes.js
@@ -1,3 +1,4 @@
+"use client";
 // pages/configuracoes.js
 import { useEffect, useState, useCallback } from "react";
 import { useSession } from "next-auth/react";

--- a/pages/gerenciar-usuarios.js
+++ b/pages/gerenciar-usuarios.js
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useSession } from "next-auth/react";

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState, useMemo } from "react";
 import { parseISO, format as formatDate } from 'date-fns';
 import { Card, CardContent } from "@/components/ui/card";

--- a/pages/metas.js
+++ b/pages/metas.js
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useSession } from "next-auth/react"; // Importa o hook de sessão

--- a/pages/oportunidades.js
+++ b/pages/oportunidades.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { addDays, addMonths, format, parseISO } from 'date-fns';

--- a/pages/pagamentos.js
+++ b/pages/pagamentos.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useSession } from "next-auth/react";

--- a/pages/relatorios/detalhamento-oportunidade.js
+++ b/pages/relatorios/detalhamento-oportunidade.js
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useSession } from "next-auth/react"; // Importa o hook de sessão

--- a/pages/relatorios/dsr.js
+++ b/pages/relatorios/dsr.js
@@ -1,3 +1,4 @@
+"use client";
 import { useState, useCallback, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useSession } from 'next-auth/react';

--- a/pages/relatorios/extrato-mensal.js
+++ b/pages/relatorios/extrato-mensal.js
@@ -1,3 +1,4 @@
+"use client";
 import { useState, useCallback, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useSession } from "next-auth/react";

--- a/pages/relatorios/pagamentos-em-atraso.js
+++ b/pages/relatorios/pagamentos-em-atraso.js
@@ -1,3 +1,4 @@
+"use client";
 import { useState, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useSession } from "next-auth/react";


### PR DESCRIPTION
## Summary
- mark pages and sidebar using `useSession` as client components
- wrap app layout with new `Providers` component for SessionProvider
- document session context fixes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fd21b4e5c832cb3e832323f1da723