### PR TITLE
feat: implement holerite import flow

### DIFF
--- a/components/ImportHoleriteModal.js
+++ b/components/ImportHoleriteModal.js
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { v4 as uuidv4 } from 'uuid';
+
+const columns = [
+  "mes","competencia","empresa","salario_base","comissao","dsr","dias_dsr",
+  "valor_bruto","valor_liquido","data_pagamento","user_email","fonte_arquivo",
+  "holerite_ID","rubricas_json","status_validacao"
+];
+
+export default function ImportHoleriteModal(){
+  const { data: session } = useSession();
+  const [file, setFile] = useState(null);
+  const [fields, setFields] = useState(() => {
+    const obj = {}; columns.forEach(c=>obj[c]=""); return obj;
+  });
+
+  useEffect(() => {
+    if(session?.user?.email){
+      setFields(f => ({ ...f, user_email: session.user.email }));
+    }
+  }, [session]);
+
+  const handleUpload = async () => {
+    if(!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    const res = await fetch('/api/import-holerite', { method:'POST', body: fd });
+    const data = await res.json();
+    if(data.fieldsExtracted){
+      const fe = data.fieldsExtracted;
+      fe.user_email = session?.user?.email || fe.user_email;
+      fe.fonte_arquivo = data.fileName;
+      fe.holerite_ID = fe.holerite_ID || uuidv4();
+      fe.status_validacao = 'pendente';
+      fe.mes = fe.data_pagamento ? fe.data_pagamento.slice(0,7) : '';
+      setFields(fe);
+    }
+  };
+
+  const handleChange = (e) => {
+    setFields({ ...fields, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async () => {
+    const payload = {};
+    columns.forEach(c => { payload[c] = fields[c] || ""; });
+    const res = await fetch('/api/holerites', {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify(payload)
+    });
+    return await res.json();
+  };
+
+  return (
+    <div>
+      <input type="file" onChange={e=>setFile(e.target.files[0])} />
+      <button type="button" onClick={handleUpload}>Upload</button>
+      {columns.map(col => (
+        <div key={col}>
+          <label>{col}</label>
+          <input name={col} value={fields[col] || ''} onChange={handleChange} />
+        </div>
+      ))}
+      <button type="button" onClick={handleSubmit}>Salvar</button>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "react-day-picker": "^9.7.0",
     "react-dom": "18.2.0",
     "recharts": "^3.0.2",
-    "nodemailer": "^6.9.11"
+    "formidable": "^3.5.1",
+    "pdf-parse": "^1.1.1",
+    "tesseract.js": "^5.0.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "autoprefixer": "10.4.17",

--- a/pages/api/holerites.js
+++ b/pages/api/holerites.js
@@ -1,0 +1,64 @@
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "./auth/[...nextauth]";
+import { getSheetData, appendRows, updateSheet } from "@/lib/googleSheetsService";
+
+export const dynamic = 'force-dynamic';
+
+const COLUMNS = [
+  "mes","competencia","empresa","salario_base","comissao","dsr","dias_dsr",
+  "valor_bruto","valor_liquido","data_pagamento","user_email","fonte_arquivo",
+  "holerite_ID","rubricas_json","status_validacao"
+];
+
+export default async function handler(req, res){
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Não autenticado" });
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Método ${req.method} não permitido.`);
+  }
+
+  try {
+    const body = req.body || {};
+    const required = ["competencia","empresa","comissao","dsr","valor_bruto","valor_liquido","user_email","fonte_arquivo","holerite_ID","status_validacao"];
+    for(const f of required){
+      if(!body[f]) return res.status(400).json({ error: `Campo obrigatório: ${f}` });
+    }
+
+    if(body.data_pagamento && !body.mes){
+      body.mes = body.data_pagamento.slice(0,7);
+    }
+
+    const { header, rows } = await getSheetData('Holerites');
+    const idIndex = header.indexOf('holerite_id');
+    let rowIndex = -1;
+    if(idIndex >=0){
+      rowIndex = rows.findIndex(r => r[idIndex] === body.holerite_ID);
+    }
+    if(rowIndex === -1){
+      const empIdx = header.indexOf('empresa');
+      const compIdx = header.indexOf('competencia');
+      const userIdx = header.indexOf('user_email');
+      const fonteIdx = header.indexOf('fonte_arquivo');
+      if(empIdx>=0 && compIdx>=0 && userIdx>=0 && fonteIdx>=0){
+        rowIndex = rows.findIndex(r => r[empIdx]===body.empresa && r[compIdx]===body.competencia && r[userIdx]===body.user_email && r[fonteIdx]===body.fonte_arquivo);
+      }
+    }
+
+    const row = COLUMNS.map(c => body[c] || "");
+    if(rowIndex >=0){
+      rows[rowIndex] = row;
+      await updateSheet('Holerites', [header, ...rows]);
+      return res.status(200).json({ success:true, holerite_ID: body.holerite_ID, updated: true });
+    } else {
+      await appendRows('Holerites', [row]);
+      return res.status(201).json({ success:true, holerite_ID: body.holerite_ID });
+    }
+  } catch (error){
+    console.error('Erro API /api/holerites', error);
+    return res.status(500).json({ error: 'Erro ao gravar holerite' });
+  }
+}

--- a/pages/api/import-holerite.js
+++ b/pages/api/import-holerite.js
@@ -1,0 +1,188 @@
+import fs from "fs";
+import formidable from "formidable";
+import pdf from "pdf-parse";
+import Tesseract from "tesseract.js";
+import { v4 as uuidv4 } from "uuid";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "./auth/[...nextauth]";
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+function parseNumeroBR(str) {
+  if (typeof str !== "string") return 0;
+  const s = str.trim();
+  if (!s) return 0;
+  const isPt = /,\d{2}$/.test(s);
+  const normalized = isPt
+    ? s.replace(/\./g, "").replace(/,/g, ".")
+    : s.replace(/,/g, "");
+  const n = Number(normalized);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function formatBRL(n) {
+  return (n ?? 0).toLocaleString("pt-BR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function calcularQuintoDiaUtil(competencia) {
+  if (!competencia) return "";
+  let month, year;
+  if (/\d{2}\/\d{4}/.test(competencia)) {
+    [month, year] = competencia.split("/");
+  } else if (/\d{4}-\d{2}/.test(competencia)) {
+    [year, month] = competencia.split("-");
+  } else {
+    return "";
+  }
+  const date = new Date(Number(year), Number(month));
+  let count = 0;
+  while (true) {
+    const day = date.getDay();
+    if (day !== 0 && day !== 6) {
+      count++;
+      if (count === 5) break;
+    }
+    date.setDate(date.getDate() + 1);
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+function toISO(brDate) {
+  if (!brDate) return "";
+  const [d, m, y] = brDate.split("/");
+  return `${y}-${m}-${d}`;
+}
+
+function extractValue(lines, regex) {
+  const l = lines.find((line) => regex.test(line));
+  if (!l) return 0;
+  const nums = l.match(/\d+[\.,]\d+/g);
+  if (!nums) return 0;
+  return parseNumeroBR(nums[nums.length - 1]);
+}
+
+function extractQuantity(lines, regex) {
+  const l = lines.find((line) => regex.test(line));
+  if (!l) return "";
+  const nums = l.match(/\d+[\.,]\d+/g);
+  if (!nums) return "";
+  return parseNumeroBR(nums[0]);
+}
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: "Não autenticado" });
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).end(`Método ${req.method} não permitido.`);
+  }
+
+  const form = formidable({ keepExtensions: true });
+  form.parse(req, async (err, fields, files) => {
+    if (err) {
+      console.error("Erro no upload", err);
+      return res.status(500).json({ error: "Erro no upload" });
+    }
+    const file = files.file;
+    if (!file) {
+      return res.status(400).json({ error: "Arquivo não encontrado" });
+    }
+
+    try {
+      const buffer = await fs.promises.readFile(file.filepath);
+      let text = "";
+      if (file.mimetype === "application/pdf") {
+        try {
+          const data = await pdf(buffer);
+          text = data.text || "";
+        } catch (e) {
+          console.debug("pdf-parse falhou, usando OCR", e);
+        }
+      }
+      if (!text.trim()) {
+        try {
+          const result = await Promise.race([
+            Tesseract.recognize(buffer, "por"),
+            new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 20000)),
+          ]);
+          text = result.data.text;
+        } catch (e) {
+          console.debug("tesseract falhou", e);
+        }
+      }
+      const texto_bruto = text;
+      const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+      const rubricas = [];
+      for (const l of lines) {
+        const m = l.match(/^(\d{3,})?\s*([A-ZÇÃÂÊÍÓÚ\s\.]+)\s+(\d+[\.,]\d+)?\s+(\d+[\.,]\d+)?\s+(\d+[\.,]\d+)?/i);
+        if (m) {
+          rubricas.push({
+            codigo: m[1] || undefined,
+            descricao: m[2].trim(),
+            referencia: m[3] ? parseNumeroBR(m[3]) : undefined,
+            provento: m[4] ? formatBRL(parseNumeroBR(m[4])) : undefined,
+            desconto: m[5] ? formatBRL(parseNumeroBR(m[5])) : undefined,
+          });
+        }
+      }
+      const numeros_extraidos = text.match(/\d+[\.,]\d+/g) || [];
+
+      const empresaMatch = text.match(/(?:RAZ[ÃA]O SOCIAL|EMPRESA|EMPREGADOR)[:\s]+([^\n]+)/i);
+      const empresa = empresaMatch ? empresaMatch[1].trim() : "";
+
+      let competencia = "";
+      const compMatch = text.match(/(\d{2}\/\d{4})/);
+      if (compMatch) competencia = compMatch[1];
+
+      const salario_base = extractValue(lines, /SAL[ÁA]RIO\s*BASE/i);
+      const comissao = extractValue(lines, /COMISS[ÃA]OES?/i);
+      const dsr = extractValue(lines, /DSR|REFLEXO\s+COMISS[ÃA]OES?\s*DSR/i);
+      const dias_dsr = extractQuantity(lines, /REFLEXO\s+COMISS[ÃA]OES?\s*DSR/i);
+      const valor_bruto = extractValue(lines, /TOTAL\s+(DE\s+)?VENCIMENTOS|PROVENTOS/i);
+      const valor_liquido = extractValue(lines, /L[IÍ]QUIDO/i);
+      const data_pagamento_raw = (text.match(/PAGAMENTO[:\s]*(\d{2}\/\d{2}\/\d{4})/) || [])[1];
+      const data_pagamento = data_pagamento_raw ? toISO(data_pagamento_raw) : calcularQuintoDiaUtil(competencia);
+      const mes = data_pagamento ? data_pagamento.slice(0, 7) : "";
+
+      const fieldsExtracted = {
+        mes,
+        competencia,
+        empresa,
+        salario_base: formatBRL(salario_base),
+        comissao: formatBRL(comissao),
+        dsr: formatBRL(dsr),
+        dias_dsr: dias_dsr ? String(dias_dsr) : "",
+        valor_bruto: formatBRL(valor_bruto),
+        valor_liquido: formatBRL(valor_liquido),
+        data_pagamento,
+        user_email: session.user.email,
+        fonte_arquivo: file.originalFilename || file.newFilename,
+        holerite_ID: uuidv4(),
+        rubricas_json: JSON.stringify(rubricas),
+        status_validacao: "pendente",
+      };
+
+      return res.status(200).json({
+        requiresMapping: true,
+        fieldsExtracted,
+        fileName: file.originalFilename || file.newFilename,
+        texto_bruto,
+        rubricas,
+        numeros_extraidos,
+      });
+    } catch (error) {
+      console.error("Erro ao processar holerite", error);
+      return res.status(500).json({ error: "Erro ao processar holerite" });
+    }
+  });
+}

--- a/pages/calcular-dsr.js
+++ b/pages/calcular-dsr.js
@@ -3,6 +3,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useSession } from 'next-auth/react';
 import RelatorioDSRTable from '@/components/RelatorioDSRTable';
 import useDiasUteis from '@/lib/useDiasUteis';
+import ImportHoleriteModal from '@/components/ImportHoleriteModal';
 
 const getAnoMes = (date) => {
   const ano = date.getFullYear();
@@ -12,6 +13,9 @@ const getAnoMes = (date) => {
 
 export default function CalcularDSRPage() {
   const { data: session, status } = useSession();
+  const [importOpen, setImportOpen] = useState(false);
+  const role = session?.user?.role ?? 'usuario';
+  const podeVer = role === 'admin';
   const [mesAno, setMesAno] = useState(getAnoMes(new Date()));
   const [pagamentos, setPagamentos] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -82,6 +86,14 @@ export default function CalcularDSRPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-gray-900">Cálculo de DSR</h1>
+        {podeVer && (
+          <button
+            onClick={() => setImportOpen(true)}
+            className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+          >
+            Importar Holerite
+          </button>
+        )}
       </div>
 
       <Card>
@@ -147,6 +159,7 @@ export default function CalcularDSRPage() {
           )}
         </CardContent>
       </Card>
+      <ImportHoleriteModal open={importOpen} onClose={() => setImportOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add dependencies for PDF and OCR handling
- implement API for holerite import with OCR and BRL formatting
- add endpoint to upsert holerite rows in sheet
- create ImportHoleriteModal component with 15-column mapping

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/formidable)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab555fd720832ca1b197e27feb303a